### PR TITLE
Removed setting log level in WpfSample (Fixes #50)

### DIFF
--- a/wpf/ReactiveUI.Samples.Routing/ViewModels/AppBootstrapper.cs
+++ b/wpf/ReactiveUI.Samples.Routing/ViewModels/AppBootstrapper.cs
@@ -39,10 +39,8 @@ namespace ReactiveUI.Samples.Routing.ViewModels
             // Bind 
             RegisterParts(dependencyResolver);
 
-            // TODO: This is a good place to set up any other app 
-            // startup tasks, like setting the logging level
-            LogHost.Default.Level = LogLevel.Debug;
-
+            // TODO: This is a good place to set up any other app startup tasks
+            
             // Navigate to the opening page of the application
             Router.Navigate.Execute(new WelcomeViewModel(this));
         }


### PR DESCRIPTION
**What kind of change does this PR introduce?**
This removes the line setting the log level for the Default logger of LogHost, because this property is readonly and can't be setted, so the project wasn't able to be build.
This fixes #50 

**What is the current behavior?**
The project ReactiveUI.Samples.Routing101 does not compile.

**What is the new behavior?**
The project ReactiveUI.Samples.Routing101 does compile and runs.

**What might this PR break?**
nothing, it just removes setting the default log level, which is not possible. The logger isn't even used in this sample

**Please check if the PR fulfills these requirements**
~~- [ ] Tests for the changes have been added (for bug fixes / features)~~
~~- [ ] Docs have been added / updated (for bug fixes / features)~~
--> not relevant here, as there are no tests for anything in this library and no docs are affected
The functionality has been verified by manual testing (There are only two buttons to click).