### PR TITLE
Fix README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,24 +7,24 @@
 
 ### This repository contains ReactiveUI samples for various target frameworks.
 
-- ### [Avalonia](https://github.com/reactiveui/ReactiveUI.Samples/tree/master/avalonia)
+- ### [Avalonia](https://github.com/reactiveui/ReactiveUI.Samples/tree/main/avalonia)
 
-- ### [Blazor](https://github.com/reactiveui/ReactiveUI.Samples/tree/master/blazor)
+- ### [Blazor](https://github.com/reactiveui/ReactiveUI.Samples/tree/main/blazor)
 
-- ### [Testing](https://github.com/reactiveui/ReactiveUI.Samples/tree/master/testing)
+- ### [Testing](https://github.com/reactiveui/ReactiveUI.Samples/tree/main/testing)
 
-- ### [Uno](https://github.com/reactiveui/ReactiveUI.Samples/tree/master/uno)
+- ### [Uno](https://github.com/reactiveui/ReactiveUI.Samples/tree/main/uno)
 
-- ### [Universal Windows Platform](https://github.com/reactiveui/ReactiveUI.Samples/tree/master/uwp)
+- ### [Universal Windows Platform](https://github.com/reactiveui/ReactiveUI.Samples/tree/main/uwp)
 
-- ### [Windows Forms](https://github.com/reactiveui/ReactiveUI.Samples/tree/master/winforms)
+- ### [Windows Forms](https://github.com/reactiveui/ReactiveUI.Samples/tree/main/winforms)
 
-- ### [Windows Presentation Foundation](https://github.com/reactiveui/ReactiveUI.Samples/tree/master/wpf)
+- ### [Windows Presentation Foundation](https://github.com/reactiveui/ReactiveUI.Samples/tree/main/wpf)
 
-- ### [Xamarin Android](https://github.com/reactiveui/ReactiveUI.Samples/tree/master/xamarin-android)
+- ### [Xamarin Android](https://github.com/reactiveui/ReactiveUI.Samples/tree/main/xamarin-android)
 
-- ### [Xamarin Forms](https://github.com/reactiveui/ReactiveUI.Samples/tree/master/xamarin-forms)
+- ### [Xamarin Forms](https://github.com/reactiveui/ReactiveUI.Samples/tree/main/xamarin-forms)
 
-- ### [Xamarin iOS](https://github.com/reactiveui/ReactiveUI.Samples/tree/master/xamarin-ios)
+- ### [Xamarin iOS](https://github.com/reactiveui/ReactiveUI.Samples/tree/main/xamarin-ios)
 
-- ### [Xamarin macOS](https://github.com/reactiveui/ReactiveUI.Samples/tree/master/xamarin-mac)
+- ### [Xamarin macOS](https://github.com/reactiveui/ReactiveUI.Samples/tree/main/xamarin-mac)


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Fix: links still point to master instead of main


**What is the current behavior?**
<!-- You can also link to an open issue here. -->
404 page not found


**What is the new behavior?**
<!-- If this is a feature change -->
Link to projects work.


**What might this PR break?**
Nothing


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

