### PR TITLE
Update nuget packages

### DIFF
--- a/xamarin-forms/MasterDetail/Android/MasterDetail.Android.csproj
+++ b/xamarin-forms/MasterDetail/Android/MasterDetail.Android.csproj
@@ -49,13 +49,13 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ReactiveUI" Version="11.*" />
-    <PackageReference Include="Xamarin.Forms" Version="4.3.*" />
-    <PackageReference Include="Xamarin.Android.Support.Design" Version="28.*" />
-    <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="28.*" />
-    <PackageReference Include="Xamarin.Android.Support.v4" Version="28.*" />
-    <PackageReference Include="Xamarin.Android.Support.v7.CardView" Version="28.*" />
-    <PackageReference Include="Xamarin.Android.Support.v7.MediaRouter" Version="28.*" />
+    <PackageReference Include="ReactiveUI" Version="11.5.35" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
+    <PackageReference Include="Xamarin.Android.Support.Design" Version="28.0.0.3" />
+    <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="28.0.0.3" />
+    <PackageReference Include="Xamarin.Android.Support.v4" Version="28.0.0.3" />
+    <PackageReference Include="Xamarin.Android.Support.v7.CardView" Version="28.0.0.3" />
+    <PackageReference Include="Xamarin.Android.Support.v7.MediaRouter" Version="28.0.0.3" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />

--- a/xamarin-forms/MasterDetail/MasterDetail/MasterDetail.csproj
+++ b/xamarin-forms/MasterDetail/MasterDetail/MasterDetail.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ReactiveUI" Version="11.*" />
-    <PackageReference Include="ReactiveUI.XamForms" Version="11.*" />
-    <PackageReference Include="Xamarin.Forms" Version="4.3.*" />
+    <PackageReference Include="ReactiveUI" Version="11.5.35" />
+    <PackageReference Include="ReactiveUI.XamForms" Version="11.5.35" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
   </ItemGroup>
 </Project>

--- a/xamarin-forms/MasterDetail/iOS/MasterDetail.iOS.csproj
+++ b/xamarin-forms/MasterDetail/iOS/MasterDetail.iOS.csproj
@@ -148,8 +148,8 @@
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ReactiveUI" Version="11.*" />
-    <PackageReference Include="Xamarin.Forms" Version="4.3.*" />
+    <PackageReference Include="ReactiveUI" Version="11.5.35" />
+    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1451" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
**What kind of change does this PR introduce?**
This PR fixes a bug that prevents the solution from building after you clone and open it in Visual Studio

**Error**: Detected package downgrade: Xamarin.Forms from 4.7.0.1351 to 4.3.0.991250. Reference the package directly from the project to select a different version.

The fix was to update the NuGet packages and I took the liberty to update anything that was out-of-date. Seems to build and run fine now after this change.

**What might this PR break?**
Nothing that I can see