### PR TITLE
Update AndriodX packages

### DIFF
--- a/Xamarin/Cinephile/Cinephile.Android/Cinephile.Android.csproj
+++ b/Xamarin/Cinephile/Cinephile.Android/Cinephile.Android.csproj
@@ -55,8 +55,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ReactiveUI.AndroidX" Version="17.*" />
-    <PackageReference Include="Xamarin.AndroidX.Palette" Version="1.0.0.7" />
-    <PackageReference Include="Xamarin.AndroidX.MediaRouter" Version="1.2.4" />
+    <PackageReference Include="Xamarin.AndroidX.Palette" Version="1.0.0.11" />
+    <PackageReference Include="Xamarin.AndroidX.MediaRouter" Version="1.2.5.3" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="LinkerPreserve.cs" />

--- a/Xamarin/Cinephile/Cinephile.UWP/Cinephile.UWP.csproj
+++ b/Xamarin/Cinephile/Cinephile.UWP/Cinephile.UWP.csproj
@@ -145,7 +145,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ReactiveUI.Uwp">
-      <Version>17.1.4</Version>
+      <Version>17.*</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2244" />
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.13" />

--- a/Xamarin/MasterDetail/MasterDetail/MasterDetail.csproj
+++ b/Xamarin/MasterDetail/MasterDetail/MasterDetail.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ReactiveUI.XamForms" Version="17.1.4" />
+    <PackageReference Include="ReactiveUI.XamForms" Version="17.*" />
     <PackageReference Include="Xamarin.Essentials" Version="1.7.0" />
   </ItemGroup>
 


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

update

**What is the current behaviour?**
<!-- You can also link to an open issue here. -->

ReactiveUI 17.0.* to 17.1.4 had a unknown version of Xamarin.Forms that relied on Xamarin.AndriodX.Core 1.7.0.1

**What is the new behaviour?**
<!-- If this is a feature change -->

ReativeUI 17.0.6 updated the packages to provide direct support for Xamarin.AndriodX.Core 1.7.0.1

**What might this PR break?**

removes requirement to include Xamarin.AndriodX.Core 1.7.0.1 and manually update packages from ReactiveUI

**Please check if the PR fulfils these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

